### PR TITLE
Add php 8.3 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         laravel: [9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-notification-event-subscriber` will be documented in this file.
 
+## 1.3.0 - 2024-12-18
+- Added Laravel 11 and PHP 8.3 supports.
+
 ## 1.2.0 - 2022-09-27
 - Added `$notifiable` parameter of the `NotificationSent` and `NotificationSending` events to `onSent()` and `enSending()` methods.
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1 | ^8.2",
+        "php": "^8.1 | ^8.2 | ^8.3",
         "illuminate/contracts": "^9.0 | ^10.0 | ^11.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request includes updates to support PHP 8.3 and Laravel 11. The most important changes are as follows:

Support for PHP 8.3 and Laravel 11:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L16-R16): Added PHP 8.3 to the testing matrix.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R7): Documented the addition of Laravel 11 and PHP 8.3 support in version 1.3.0.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R19): Updated the `require` section to include PHP 8.3 and Laravel 11.